### PR TITLE
Feature: spell slots tracking

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -1382,6 +1382,33 @@ input[type="number"] {
     font-weight: bold;
     cursor: pointer;
   }
+
+  .wrap-spell-buttons{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-left: 10px;
+  }
+
+  .edit-spell {
+    cursor: pointer;
+    border: 1.5px solid #979AA4;
+    font-weight: bold;
+    background-color: #EBE1AD;
+    border-radius: 15px;
+    box-shadow: 0 0 3px #979AA4;
+    padding: 0px;
+    height: 30px;
+    min-height: 20px;
+    width: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    color: #979AA4;
+    margin: 2px;
+    font-size: 1.3rem;
+  }
   
 
 /* spell casting */

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -1364,14 +1364,23 @@ input[type="number"] {
   } */
 
   .spell-info  {  
-     display: grid;
-      grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
-      grid-template-rows: 1fr;
-      gap: 5px 5px;
-      grid-auto-flow: row;
-      grid-template-areas:
-        ". . . . .";
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
+    grid-template-rows: 1fr;
+    gap: 5px 5px;
+    grid-auto-flow: row;
+    grid-template-areas:
+      ". . . . . .";
+    margin-bottom: 20px;
   
+  }
+
+  .reset-spell-button{
+    text-align: center;
+    color: #822000;
+    border-radius: 15px;
+    font-weight: bold;
+    cursor: pointer;
   }
   
 

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -1349,3 +1349,79 @@ input[type="number"] {
 .used-spells {
   text-decoration: line-through;
 }
+
+.spell-level {
+  margin-right: 1rem;
+  line-height: 30px;
+}
+
+/* .spell-info {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-template-rows: 1fr;
+  grid-column-gap: 0px;
+  grid-row-gap: 0px;
+  } */
+
+  .spell-info  {  
+     display: grid;
+      grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+      grid-template-rows: 1fr;
+      gap: 5px 5px;
+      grid-auto-flow: row;
+      grid-template-areas:
+        ". . . . .";
+  
+  }
+  
+
+/* spell casting */
+
+.checkbox-wrapper{
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+/* checkbox */
+.checkbox-wrapper input[type="checkbox"] {
+  /* removing default appearance */
+  -webkit-appearance: none;
+  appearance: none;
+  /* creating a custom design */
+  width: 1.6em;
+  height: 1.6em;
+  /* border-radius: 0.15em; */
+  margin-right: 0.5em;
+  border: 0.15em solid #822000;
+  border-radius: 10px;
+  box-shadow: 0 0 5px #979AA4;
+  outline: none;
+  cursor: pointer;
+}
+
+input.checked {
+  background-color: #822000;
+  position: relative;
+}
+
+input.checked::before {
+  content: "\2714";
+  font-size: 1.15em;
+  color: #EBE1AD;
+  position: absolute;
+  right: 3px;
+  top: -3px;
+}
+
+.checkbox-wrapper input[type="checkbox"]:disabled {
+  border-color: #c0c0c0;
+  background-color: #c0c0c0;
+}
+
+.checkbox-wrapper input[type="checkbox"]:disabled + span {
+  color: #c0c0c0;
+}
+
+/* .checkbox-wrapper input[type="checkbox"]:focus {
+  box-shadow: 0 0 20px #007a7e;
+} */

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -1343,3 +1343,9 @@ input[type="number"] {
   outline: 2px solid #822000;
 }
 /* scroll to active initiative */
+
+/* spell casting */
+
+.used-spells {
+  text-decoration: line-through;
+}

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -1441,11 +1441,11 @@ input.checked {
 }
 
 input.checked::before {
-  content: "\2714";
-  font-size: 1.15em;
+  content: "\2718";
+  font-size: 1.20em;
   color: #EBE1AD;
   position: absolute;
-  right: 3px;
+  right: 5px;
   top: -3px;
 }
 

--- a/src/components/app/DungeonMasterApp.js
+++ b/src/components/app/DungeonMasterApp.js
@@ -40,6 +40,7 @@ import {
   toggleCreatureShare,
   toggleCreatureHitPointsShare,
   updateCreatureSpells,
+  resetSpells,
 } from '../../state/CreatureManager';
 import {
   save,
@@ -132,6 +133,7 @@ function DungeonMasterApp({
     toggleCreatureShare: updateBattle(toggleCreatureShare),
     toggleCreatureHitPointsShare: updateBattle(toggleCreatureHitPointsShare),
     updateCreatureSpells: updateBattle(updateCreatureSpells),
+    resetSpells: updateBattle(resetSpells),
   };
 
   const onScrollActiveInitiative = () => {

--- a/src/components/app/DungeonMasterApp.js
+++ b/src/components/app/DungeonMasterApp.js
@@ -39,6 +39,7 @@ import {
   toggleCreatureLock,
   toggleCreatureShare,
   toggleCreatureHitPointsShare,
+  updateCreatureSpells,
 } from '../../state/CreatureManager';
 import {
   save,
@@ -130,6 +131,7 @@ function DungeonMasterApp({
     toggleCreatureLock: updateBattle(toggleCreatureLock, false),
     toggleCreatureShare: updateBattle(toggleCreatureShare),
     toggleCreatureHitPointsShare: updateBattle(toggleCreatureHitPointsShare),
+    updateCreatureSpells: updateBattle(updateCreatureSpells),
   };
 
   const onScrollActiveInitiative = () => {

--- a/src/components/app/DungeonMasterApp.js
+++ b/src/components/app/DungeonMasterApp.js
@@ -41,6 +41,8 @@ import {
   toggleCreatureHitPointsShare,
   updateCreatureSpells,
   resetSpells,
+  addSpellSlot,
+  removeSpellSlot,
 } from '../../state/CreatureManager';
 import {
   save,
@@ -134,6 +136,8 @@ function DungeonMasterApp({
     toggleCreatureHitPointsShare: updateBattle(toggleCreatureHitPointsShare),
     updateCreatureSpells: updateBattle(updateCreatureSpells),
     resetSpells: updateBattle(resetSpells),
+    addSpellSlot: updateBattle(addSpellSlot),
+    removeSpellSlot: updateBattle(removeSpellSlot),
   };
 
   const onScrollActiveInitiative = () => {

--- a/src/components/buttons/CheckBox.js
+++ b/src/components/buttons/CheckBox.js
@@ -1,0 +1,20 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+
+function Checkbox({
+  label, checked, onChange, ...props
+}) {
+  return (
+    <div className="checkbox-wrapper">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+        className={checked ? 'checked' : ''}
+        {...props}
+      />
+    </div>
+  );
+}
+
+export default Checkbox;

--- a/src/components/creature/CreatureWrapper.js
+++ b/src/components/creature/CreatureWrapper.js
@@ -142,6 +142,8 @@ class CreatureWrapper extends Component {
     const classes = `creature-wrapper ${activeClassModifier}`;
     const creatureAriaLabel = getCreatureAriaLabel(creature, active, expanded);
     const {
+      addSpellSlot,
+      removeSpellSlot,
       resetSpells,
       updateCreatureSpells,
       removeCreature,
@@ -217,6 +219,8 @@ class CreatureWrapper extends Component {
                       active={active}
                       updateCreatureSpells={updateCreatureSpells}
                       resetSpells={resetSpells}
+                      addSpellSlot={addSpellSlot}
+                      removeSpellSlot={removeSpellSlot}
                     />
                   )}
 

--- a/src/components/creature/CreatureWrapper.js
+++ b/src/components/creature/CreatureWrapper.js
@@ -142,6 +142,7 @@ class CreatureWrapper extends Component {
     const classes = `creature-wrapper ${activeClassModifier}`;
     const creatureAriaLabel = getCreatureAriaLabel(creature, active, expanded);
     const {
+      resetSpells,
       updateCreatureSpells,
       removeCreature,
       removeNoteFromCreature,
@@ -215,6 +216,7 @@ class CreatureWrapper extends Component {
                       creature={creature}
                       active={active}
                       updateCreatureSpells={updateCreatureSpells}
+                      resetSpells={resetSpells}
                     />
                   )}
 

--- a/src/components/creature/CreatureWrapper.js
+++ b/src/components/creature/CreatureWrapper.js
@@ -9,6 +9,7 @@ import CreatureRemover from '../buttons/CreatureRemover';
 import { getAvailableConditions } from '../../state/ConditionsManager';
 import { getHitPointsBar, shouldShowHitPoints } from '../../display/displayLogic';
 import CreatureStats from './CreatureStats';
+import SpellCasting from './SpellCasting';
 
 function getCreatureAriaLabel(creature, active, expanded) {
   const { name } = creature;
@@ -38,7 +39,7 @@ class CreatureWrapper extends Component {
     super(props);
 
     this.state = {
-      expanded: false,
+      expanded: true,
     };
 
     this.expandCreatureHandler = this.expandCreatureHandler.bind(this);
@@ -170,6 +171,8 @@ class CreatureWrapper extends Component {
       rightPercentage,
     ] = getHitPointsBar(creatureHealthPoints, maxHealthPoints, alive, showHitPoints);
 
+    console.log('current state', creature);
+
     return (
       <>
         <section
@@ -206,6 +209,13 @@ class CreatureWrapper extends Component {
                     showHealth={showHitPoints}
                     playerSession={playerSession}
                   />
+                  {creature.spellData && (
+                    <SpellCasting
+                      spellData={creature.spellData}
+                      active={active}
+                    />
+                  )}
+
                   {creature.apiData && (
                   <div>
                     <CreatureStats

--- a/src/components/creature/CreatureWrapper.js
+++ b/src/components/creature/CreatureWrapper.js
@@ -142,6 +142,7 @@ class CreatureWrapper extends Component {
     const classes = `creature-wrapper ${activeClassModifier}`;
     const creatureAriaLabel = getCreatureAriaLabel(creature, active, expanded);
     const {
+      updateCreatureSpells,
       removeCreature,
       removeNoteFromCreature,
       toggleCreatureLock,
@@ -171,7 +172,7 @@ class CreatureWrapper extends Component {
       rightPercentage,
     ] = getHitPointsBar(creatureHealthPoints, maxHealthPoints, alive, showHitPoints);
 
-    console.log('current state', creature);
+    console.log('current creature state', creature);
 
     return (
       <>
@@ -211,8 +212,9 @@ class CreatureWrapper extends Component {
                   />
                   {creature.spellData && (
                     <SpellCasting
-                      spellData={creature.spellData}
+                      creature={creature}
                       active={active}
+                      updateCreatureSpells={updateCreatureSpells}
                     />
                   )}
 

--- a/src/components/creature/SpellCasting.js
+++ b/src/components/creature/SpellCasting.js
@@ -1,0 +1,44 @@
+/* eslint-disable max-len */
+import React from 'react';
+
+export default function SpellCasting({
+  spellData,
+  active,
+}) {
+  console.log('spells', spellData);
+
+  const onChangeSlot = (event, level, slotIndex) => {
+    const { checked } = event.target;
+    console.log('checked', checked);
+    console.log('level', level);
+    console.log('slotIndex', slotIndex);
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <p>{spellData.school}</p>
+      <p>{spellData.dc}</p>
+      <p>{spellData.modifier}</p>
+      <p>{spellData.ability}</p>
+      {spellData.spells.map((item) => (
+        <div style={{ display: 'flex', flexDirection: 'column' }} key={item.level}>
+          {/* <input value={item} type="checkbox" /> */}
+
+          <div style={{ display: 'flex', flexDirection: 'row' }}>
+          <span>
+            Level 
+            {' '}
+            {item.level}
+          </span>
+            {item.slots.map((slot) => (
+              <div key={slot.slotIndex}>
+                <input onChange={(ev) => onChangeSlot(ev, item.level, slot.slotIndex)} checked={slot.used} type="checkbox" />
+              </div>
+            ))}
+          </div>
+
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/creature/SpellCasting.js
+++ b/src/components/creature/SpellCasting.js
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable max-len */
-import React from 'react';
+import React, { useState } from 'react';
 import { capitalizeWord } from '../../util/characterSheet';
 import Checkbox from '../buttons/CheckBox';
 
@@ -12,14 +12,41 @@ export default function SpellCasting({
   active,
   updateCreatureSpells,
   resetSpells,
+  addSpellSlot,
+  removeSpellSlot,
 }) {
   const { spellData } = creature;
+
+  const [isHovering, setIsHovering] = useState(false);
+  const [hoverLevel, setLevel] = useState('');
+
+  const handleMouseOver = (level) => {
+    setLevel(level);
+    setIsHovering(true);
+  };
+
+  const onClickRandom = () => {
+    setIsHovering(false);
+    setLevel('');
+  };
+
   if (!spellData) return null;
+
   console.log('SpellCasting data', spellData);
 
   const onChangeSlot = (event, level, slotIndex) => {
     const { checked } = event.target;
     updateCreatureSpells(creature.id, { level, slotIndex, value: checked });
+  };
+
+  const onAddSpellSlot = (level) => {
+    addSpellSlot(creature.id, level);
+    handleMouseOver(level);
+  };
+
+  const onRemoveSpellSlot = (level) => {
+    removeSpellSlot(creature.id, level);
+    handleMouseOver(level);
   };
 
   const onResetSpells = () => {
@@ -62,7 +89,7 @@ export default function SpellCasting({
         if (item.level === '0') return null;
         const isDisabled = slotsExpired(item.slots);
         return (
-          <div key={item.level} style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+          <div onFocus={() => {}} onMouseOver={() => handleMouseOver(item.level)} onClick={onClickRandom} key={item.level} style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
             <span
               className={`spell-level ${isDisabled ? 'used-spells' : ''}`}
             >
@@ -77,7 +104,17 @@ export default function SpellCasting({
                 onChange={(ev) => onChangeSlot(ev, item.level, slot.slotIndex)}
               />
             ))}
-            
+            {isHovering && item.level === hoverLevel && !isDisabled && (
+            <div className="wrap-spell-buttons">
+              <button onClick={() => onRemoveSpellSlot(item.level)} type="button" className="edit-spell">
+                -
+              </button>
+              <button onClick={() => onAddSpellSlot(item.level)} type="button" className="edit-spell">
+                +
+              </button>
+            </div>
+            )}
+
           </div>
         );
       })}

--- a/src/components/creature/SpellCasting.js
+++ b/src/components/creature/SpellCasting.js
@@ -1,5 +1,7 @@
 /* eslint-disable max-len */
 import React from 'react';
+import { capitalizeWord } from '../../util/characterSheet';
+import Checkbox from '../buttons/CheckBox';
 
 const slotsExpired = (slots) => slots.every((slot) => slot.used);
 
@@ -19,27 +21,51 @@ export default function SpellCasting({
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <p>{spellData.school}</p>
-      <p>{spellData.dc}</p>
-      <p>{spellData.modifier}</p>
-      <p>{spellData.ability}</p>
+      <div className="spell-info">
+        <span className="spell-label">
+          <b>School:</b>
+          {' '}
+          { capitalizeWord(spellData.school)}
+        </span>
+        <span className="spell-label">
+          <b>Level:</b>
+          {' '}
+          {spellData.level}
+        </span>
+        <span className="spell-label">
+          <b>Save DC:</b>
+          {' '}
+          {spellData.saveDC}
+        </span>
+        <span className="spell-label">
+          <b>Spell MOD:</b>
+          {' '}
+          {spellData.modifier}
+        </span>
+        <span className="spell-label">
+          <b>Spell Class:</b>
+          {' '}
+          {spellData.ability}
+        </span>
+      </div>
       {spellData.spells.map((item) => {
         const isDisabled = slotsExpired(item.slots) && item.level !== '0';
         return (
-          <div style={{ display: 'flex', flexDirection: 'column' }} key={item.level}>
-            <div style={{ display: 'flex', flexDirection: 'row' }}>
-              <p className={isDisabled ? 'used-spells' : ''}>
-                Level
-                {' '}
-                {item.level}
-              </p>
-              {item.slots.map((slot) => (
-                <div key={slot.slotIndex}>
-                  <input onChange={(ev) => onChangeSlot(ev, item.level, slot.slotIndex)} checked={slot.used} type="checkbox" />
-                </div>
-              ))}
-            </div>
-
+          <div key={item.level} style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+            <span
+              className={`spell-level ${isDisabled ? 'used-spells' : ''}`}
+            >
+              Level
+              {' '}
+              {item.level}
+            </span>
+            {item.slots.map((slot) => (
+              <Checkbox
+                key={slot.slotIndex}
+                checked={slot.used}
+                onChange={(ev) => onChangeSlot(ev, item.level, slot.slotIndex)}
+              />
+            ))}
           </div>
         );
       })}

--- a/src/components/creature/SpellCasting.js
+++ b/src/components/creature/SpellCasting.js
@@ -1,17 +1,20 @@
 /* eslint-disable max-len */
 import React from 'react';
 
+const slotsExpired = (slots) => slots.every((slot) => slot.used);
+
 export default function SpellCasting({
-  spellData,
+  creature,
   active,
+  updateCreatureSpells,
 }) {
-  console.log('spells', spellData);
+  const { spellData } = creature;
+  if (!spellData) return null;
+  console.log('SpellCasting data', spellData);
 
   const onChangeSlot = (event, level, slotIndex) => {
     const { checked } = event.target;
-    console.log('checked', checked);
-    console.log('level', level);
-    console.log('slotIndex', slotIndex);
+    updateCreatureSpells(creature.id, { level, slotIndex, value: checked });
   };
 
   return (
@@ -20,25 +23,26 @@ export default function SpellCasting({
       <p>{spellData.dc}</p>
       <p>{spellData.modifier}</p>
       <p>{spellData.ability}</p>
-      {spellData.spells.map((item) => (
-        <div style={{ display: 'flex', flexDirection: 'column' }} key={item.level}>
-          {/* <input value={item} type="checkbox" /> */}
+      {spellData.spells.map((item) => {
+        const isDisabled = slotsExpired(item.slots) && item.level !== '0';
+        return (
+          <div style={{ display: 'flex', flexDirection: 'column' }} key={item.level}>
+            <div style={{ display: 'flex', flexDirection: 'row' }}>
+              <p className={isDisabled ? 'used-spells' : ''}>
+                Level
+                {' '}
+                {item.level}
+              </p>
+              {item.slots.map((slot) => (
+                <div key={slot.slotIndex}>
+                  <input onChange={(ev) => onChangeSlot(ev, item.level, slot.slotIndex)} checked={slot.used} type="checkbox" />
+                </div>
+              ))}
+            </div>
 
-          <div style={{ display: 'flex', flexDirection: 'row' }}>
-          <span>
-            Level 
-            {' '}
-            {item.level}
-          </span>
-            {item.slots.map((slot) => (
-              <div key={slot.slotIndex}>
-                <input onChange={(ev) => onChangeSlot(ev, item.level, slot.slotIndex)} checked={slot.used} type="checkbox" />
-              </div>
-            ))}
           </div>
-
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/src/components/creature/SpellCasting.js
+++ b/src/components/creature/SpellCasting.js
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable max-len */
 import React from 'react';
 import { capitalizeWord } from '../../util/characterSheet';
@@ -9,6 +11,7 @@ export default function SpellCasting({
   creature,
   active,
   updateCreatureSpells,
+  resetSpells,
 }) {
   const { spellData } = creature;
   if (!spellData) return null;
@@ -19,8 +22,12 @@ export default function SpellCasting({
     updateCreatureSpells(creature.id, { level, slotIndex, value: checked });
   };
 
+  const onResetSpells = () => {
+    resetSpells(creature.id);
+  };
+
   return (
-    <div style={{ display: 'flex', flexDirection: 'column' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', marginBottom: 30 }}>
       <div className="spell-info">
         <span className="spell-label">
           <b>School:</b>
@@ -47,9 +54,13 @@ export default function SpellCasting({
           {' '}
           {spellData.ability}
         </span>
+        <span className="reset-spell-button" onClick={onResetSpells}>
+          ↻ Reset Spells
+        </span>
       </div>
       {spellData.spells.map((item) => {
-        const isDisabled = slotsExpired(item.slots) && item.level !== '0';
+        if (item.level === '0') return null;
+        const isDisabled = slotsExpired(item.slots);
         return (
           <div key={item.level} style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
             <span
@@ -66,6 +77,7 @@ export default function SpellCasting({
                 onChange={(ev) => onChangeSlot(ev, item.level, slot.slotIndex)}
               />
             ))}
+            
           </div>
         );
       })}

--- a/src/components/page/CreateCreatureForm.js
+++ b/src/components/page/CreateCreatureForm.js
@@ -10,6 +10,7 @@ import D20Icon from '../icons/D20Icon';
 import rollDice from '../../util/rollDice';
 import DropdownOption from '../creature/toolbar/DropdownOption';
 import { calculateAbilityModifier, getArmorClass } from '../../util/characterSheet';
+import getCreatureSpellData from '../../util/spells';
 
 const BASE_API_URL = 'https://www.dnd5eapi.co';
 
@@ -137,6 +138,7 @@ function CreateCreatureForm({ createCreatureErrors, createCreature: propsCreateC
           name: monster.name,
           healthPoints: data.hit_points,
           armorClass: getArmorClass(data.armor_class),
+          spellData: getCreatureSpellData(data.special_abilities),
           apiData: data,
         }));
       })

--- a/src/components/page/CreateCreatureForm.js
+++ b/src/components/page/CreateCreatureForm.js
@@ -10,7 +10,7 @@ import D20Icon from '../icons/D20Icon';
 import rollDice from '../../util/rollDice';
 import DropdownOption from '../creature/toolbar/DropdownOption';
 import { calculateAbilityModifier, getArmorClass } from '../../util/characterSheet';
-import getCreatureSpellData from '../../util/spells';
+import { getCreatureSpellData } from '../../util/spells';
 
 const BASE_API_URL = 'https://www.dnd5eapi.co';
 

--- a/src/state/CreatureManager.js
+++ b/src/state/CreatureManager.js
@@ -1,4 +1,5 @@
 import getSecondsElapsed from './TimeManager';
+import { findAndChangeSpellSlot } from '../util/spells';
 import { allConditions, addCondition, removeCondition } from './ConditionsManager';
 
 function findCreature(creatures, creatureId) {
@@ -28,6 +29,19 @@ export function killCreature(state, creatureId) {
     { alive: false, healthPoints, conditions: newConditions },
     ariaAnnouncement,
   );
+}
+
+export function updateCreatureSpells(state, creatureId, currentSpell) {
+  const creature = findCreature(state.creatures, creatureId);
+
+  const ariaAnnouncement = `Spells changed for ${creature.name}`;
+  const { spellData } = creature;
+
+  const newSpells = findAndChangeSpellSlot(spellData.spells, currentSpell);
+
+  const newData = { ...spellData, spells: newSpells };
+
+  return updateCreature(state, creatureId, { spellData: newData }, ariaAnnouncement);
 }
 
 export function stabalizeCreature(state, creatureId) {

--- a/src/state/CreatureManager.js
+++ b/src/state/CreatureManager.js
@@ -44,6 +44,22 @@ export function updateCreatureSpells(state, creatureId, currentSpell) {
   return updateCreature(state, creatureId, { spellData: newData }, ariaAnnouncement);
 }
 
+export function resetSpells(state, creatureId) {
+  const creature = findCreature(state.creatures, creatureId);
+
+  const ariaAnnouncement = `Spells changed for ${creature.name}`;
+  const { spellData } = creature;
+
+  const newSpells = spellData.spells.map((spell) => {
+    const slots = spell.slots.map((slot) => ({ ...slot, used: false }));
+    return { ...spell, slots };
+  });
+
+  const newData = { ...spellData, spells: newSpells };
+
+  return updateCreature(state, creatureId, { spellData: newData }, ariaAnnouncement);
+}
+
 export function stabalizeCreature(state, creatureId) {
   const creature = findCreature(state.creatures, creatureId);
   const ariaAnnouncement = `${creature.name} stabalized`;

--- a/src/state/CreatureManager.js
+++ b/src/state/CreatureManager.js
@@ -60,6 +60,44 @@ export function resetSpells(state, creatureId) {
   return updateCreature(state, creatureId, { spellData: newData }, ariaAnnouncement);
 }
 
+export function addSpellSlot(state, creatureId, spellLevel) {
+  const creature = findCreature(state.creatures, creatureId);
+
+  const ariaAnnouncement = `Spells slot added for ${creature.name}`;
+  const { spellData } = creature;
+
+  const newSpells = spellData.spells.map((spell) => {
+    if (spell.level === spellLevel) {
+      const { slots } = spell;
+      return { ...spell, slots: [...slots, { used: false, slotIndex: slots.length + 1 }] };
+    }
+    return spell;
+  });
+
+  const newData = { ...spellData, spells: newSpells };
+
+  return updateCreature(state, creatureId, { spellData: newData }, ariaAnnouncement);
+}
+
+export function removeSpellSlot(state, creatureId, spellLevel) {
+  const creature = findCreature(state.creatures, creatureId);
+
+  const ariaAnnouncement = `Spells slot removed for ${creature.name}`;
+  const { spellData } = creature;
+
+  const newSpells = spellData.spells.map((spell) => {
+    if (spell.level === spellLevel) {
+      const { slots } = spell;
+      return { ...spell, slots: slots.filter((_, index) => slots.length - index !== 1) };
+    }
+    return spell;
+  });
+
+  const newData = { ...spellData, spells: newSpells };
+
+  return updateCreature(state, creatureId, { spellData: newData }, ariaAnnouncement);
+}
+
 export function stabalizeCreature(state, creatureId) {
   const creature = findCreature(state.creatures, creatureId);
   const ariaAnnouncement = `${creature.name} stabalized`;

--- a/src/state/CreatureManager.js
+++ b/src/state/CreatureManager.js
@@ -112,7 +112,7 @@ export function getRawName(name) {
 }
 
 export function createCreature(creatureId, {
-  armorClass, name, number, initiative, healthPoints,apiData,
+  armorClass, name, number, initiative, healthPoints, apiData, spellData,
 }) {
   const groupedName = number ? `${name} #${number}` : name;
   return {
@@ -129,7 +129,8 @@ export function createCreature(creatureId, {
     locked: false,
     shared: true,
     hitPointsShared: true,
-    apiData
+    apiData,
+    spellData,
   };
 }
 

--- a/src/state/CreatureManager.js
+++ b/src/state/CreatureManager.js
@@ -88,10 +88,12 @@ export function removeSpellSlot(state, creatureId, spellLevel) {
   const newSpells = spellData.spells.map((spell) => {
     if (spell.level === spellLevel) {
       const { slots } = spell;
-      return { ...spell, slots: slots.filter((_, index) => slots.length - index !== 1) };
+      const updatedSlots = slots.filter((_, index) => slots.length - index !== 1);
+      if (updatedSlots.length === 0) return null;
+      return { ...spell, slots: updatedSlots };
     }
     return spell;
-  });
+  }).filter((spell) => spell !== null);
 
   const newData = { ...spellData, spells: newSpells };
 

--- a/src/util/spells.js
+++ b/src/util/spells.js
@@ -1,0 +1,44 @@
+const getCreatureSpellData = (abilities) => {
+  if (!abilities) return undefined;
+  const data = abilities.find((ability) => ability.name === 'Spellcasting');
+  if (!data || !data?.spellcasting) return undefined;
+
+  const { spellcasting } = data;
+
+  const apiSpells = spellcasting.spells ?? [];
+
+  // for cantrips
+  const spells = [{ level: '0', count: 100, slots: [] }];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const [key, value] of Object.entries(spellcasting.slots)) {
+    spells.push({
+      level: key,
+      count: value,
+      slots: Array.from({ length: value }, (_, i) => ({ used: false, slotIndex: i })),
+    });
+  }
+
+  const newSpells = spells.map((spell) => {
+    const knownSpells = apiSpells.filter((s) => `${s.level}` === spell.level);
+    return {
+      ...spell,
+      knownSpells,
+    };
+  });
+
+  console.log('newSpells: ', newSpells);
+
+  const spellData = {
+    saveDC: spellcasting.dc,
+    modifier: spellcasting.modifier,
+    level: spellcasting.level,
+    school: spellcasting.school,
+    ability: spellcasting.ability.name,
+    spells: newSpells,
+  };
+
+  return spellData;
+};
+
+export default getCreatureSpellData;

--- a/src/util/spells.js
+++ b/src/util/spells.js
@@ -1,4 +1,5 @@
-const getCreatureSpellData = (abilities) => {
+/* eslint-disable max-len */
+export const getCreatureSpellData = (abilities) => {
   if (!abilities) return undefined;
   const data = abilities.find((ability) => ability.name === 'Spellcasting');
   if (!data || !data?.spellcasting) return undefined;
@@ -27,7 +28,6 @@ const getCreatureSpellData = (abilities) => {
     };
   });
 
-  console.log('newSpells: ', newSpells);
 
   const spellData = {
     saveDC: spellcasting.dc,
@@ -41,4 +41,22 @@ const getCreatureSpellData = (abilities) => {
   return spellData;
 };
 
-export default getCreatureSpellData;
+export const changeSpellSlot = (slots, { slotIndex, value }) => slots.map((currentSlot) => {
+  if (currentSlot.slotIndex === slotIndex) {
+    return {
+      ...currentSlot,
+      used: value,
+    };
+  }
+  return currentSlot;
+});
+
+export const findAndChangeSpellSlot = (spells, { level, slotIndex, value }) => spells.map((currentLevel) => {
+  if (currentLevel.level === level) {
+    return {
+      ...currentLevel,
+      slots: changeSpellSlot(currentLevel.slots, { slotIndex, value }),
+    };
+  }
+  return currentLevel;
+});


### PR DESCRIPTION
Spells management for fetched creature:

<img width="1459" alt="Screenshot 2023-03-29 at 18 02 00" src="https://user-images.githubusercontent.com/9382283/228581914-3680233d-4a46-4688-a407-401f1d78fe8d.png">

Demo:



https://user-images.githubusercontent.com/9382283/228583774-a9e2bc0b-9763-44e2-b8f7-6d6b3bebc709.mp4




To-Do:
- ~~Add spell Level (dropdown) for characters to add new slots~~ #3
- ~~Remove spell level when last slot is removed~~ #3 
- ~~Beautify API spells in creature stats (DnD Beyond like)~~ #4 
- Fix tests
- Add option to configure player/NPC caster stats like API casters:

<img width="1359" alt="Screenshot 2023-03-31 at 11 44 43" src="https://user-images.githubusercontent.com/9382283/229072431-89ce31b0-b2f2-4184-942b-397ac13f0b15.png">


